### PR TITLE
Separate logic from component

### DIFF
--- a/src/components/CalendarBoard/index.jsx
+++ b/src/components/CalendarBoard/index.jsx
@@ -1,11 +1,8 @@
 import React from "react";
 import CalendarElement from "../CalendarElement";
 import { GridList } from "@material-ui/core";
+import createCalendar from "../../services/calendar";
 import "./style.css";
-
-import dayjs from "dayjs";
-import "dayjs/locale/ja";
-dayjs.locale("ja");
 
 const calendar = createCalendar();
 

--- a/src/components/CalendarBoard/index.jsx
+++ b/src/components/CalendarBoard/index.jsx
@@ -16,7 +16,16 @@ const createCalendar = () => {
   // fill(0)で初期化する
   // 1~35の連番の配列を得るため、map関数でインデックス番号を取得する
   // 月の最初の日の値が0になるように配列の要素をシフトさせる
-  return Array(35).fill(0).map((_, i) => i - firstDayIndex);
+  return Array(35)
+    .fill(0)
+    .map((_, i) => {
+      // 月の最初の日からの差分を取得
+      // index値を日付として表示
+      const diffFromFirstDay = i - firstDayIndex;
+      const day = firstDay.add(diffFromFirstDay, "day");
+
+      return day;
+    });
 };
 
 const calendar = createCalendar();
@@ -26,8 +35,8 @@ const CalendarBoard = () => {
     <div className="container">
       <GridList className="grid" cols={7} spacing={0} cellHeight="auto">
         {calendar.map(c => (
-          <li>
-            <div className="element">{c}</div>
+          <li key={c.toISOString()}>
+            <div className="element">{c.format("D")}</div>
           </li>
         ))}
       </GridList>

--- a/src/components/CalendarBoard/index.jsx
+++ b/src/components/CalendarBoard/index.jsx
@@ -7,28 +7,6 @@ import dayjs from "dayjs";
 import "dayjs/locale/ja";
 dayjs.locale("ja");
 
-//今月の最初の日を追加
-const firstDay = dayjs().startOf("month");
-
-// 最初の日の曜日を取得
-const firstDayIndex = firstDay.day();
-
-const createCalendar = () => {
-  // fill(0)で初期化する
-  // 1~35の連番の配列を得るため、map関数でインデックス番号を取得する
-  // 月の最初の日の値が0になるように配列の要素をシフトさせる
-  return Array(35)
-    .fill(0)
-    .map((_, i) => {
-      // 月の最初の日からの差分を取得
-      // index値を日付として表示
-      const diffFromFirstDay = i - firstDayIndex;
-      const day = firstDay.add(diffFromFirstDay, "day");
-
-      return day;
-    });
-};
-
 const calendar = createCalendar();
 
 const CalendarBoard = () => {

--- a/src/components/CalendarBoard/index.jsx
+++ b/src/components/CalendarBoard/index.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React from "react";
+import CalendarElement from "../CalendarElement";
 import { GridList } from "@material-ui/core";
 import "./style.css";
 
@@ -36,7 +37,7 @@ const CalendarBoard = () => {
       <GridList className="grid" cols={7} spacing={0} cellHeight="auto">
         {calendar.map(c => (
           <li key={c.toISOString()}>
-            <div className="element">{c.format("D")}</div>
+            <CalendarElement>{c.format("D")}</CalendarElement>
           </li>
         ))}
       </GridList>

--- a/src/components/CalendarBoard/index.jsx
+++ b/src/components/CalendarBoard/index.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import CalendarElement from "../CalendarElement";
 import { GridList } from "@material-ui/core";
-import createCalendar from "../../services/calendar";
+import { createCalendar } from "../../services/calendar";
 import "./style.css";
 
 const calendar = createCalendar();

--- a/src/components/CalendarBoard/style.css
+++ b/src/components/CalendarBoard/style.css
@@ -2,12 +2,6 @@
   height: 90vh;
 }
 
-.element {
-  border-right: 1px solid #ccc;
-  border-bottom: 1px solid #ccc;
-  height: 18vh;
-}
-
 .grid {
   border-left: 1px solid #ccc;
   border-top: 1px solid #ccc;

--- a/src/components/CalendarElement/index.jsx
+++ b/src/components/CalendarElement/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import "./style.css";
+
+const CalendarElement = ({ children }) => {
+  return (
+    <div className="element">
+      <div className="date">{children}</div>
+    </div>
+  );
+};
+
+export default CalendarElement;

--- a/src/components/CalendarElement/style.css
+++ b/src/components/CalendarElement/style.css
@@ -1,0 +1,5 @@
+.element {
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  height: 18vh;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 
+import dayjs from "dayjs";
+import "dayjs/locale/ja";
+dayjs.locale("ja");
+
 ReactDOM.render(
   <React.StrictMode>
     <App />

--- a/src/services/calendar.js
+++ b/src/services/calendar.js
@@ -6,7 +6,7 @@ const firstDay = dayjs().startOf("month");
 // 最初の日の曜日を取得
 const firstDayIndex = firstDay.day();
 
-const createCalendar = () => {
+export const createCalendar = () => {
   // fill(0)で初期化する
   // 1~35の連番の配列を得るため、map関数でインデックス番号を取得する
   // 月の最初の日の値が0になるように配列の要素をシフトさせる
@@ -21,5 +21,3 @@ const createCalendar = () => {
       return day;
     });
 };
-
-export default createCalendar;

--- a/src/services/calendar.js
+++ b/src/services/calendar.js
@@ -1,0 +1,25 @@
+import dayjs from "dayjs";
+
+//今月の最初の日を追加
+const firstDay = dayjs().startOf("month");
+
+// 最初の日の曜日を取得
+const firstDayIndex = firstDay.day();
+
+const createCalendar = () => {
+  // fill(0)で初期化する
+  // 1~35の連番の配列を得るため、map関数でインデックス番号を取得する
+  // 月の最初の日の値が0になるように配列の要素をシフトさせる
+  return Array(35)
+    .fill(0)
+    .map((_, i) => {
+      // 月の最初の日からの差分を取得
+      // index値を日付として表示
+      const diffFromFirstDay = i - firstDayIndex;
+      const day = firstDay.add(diffFromFirstDay, "day");
+
+      return day;
+    });
+};
+
+export default createCalendar;


### PR DESCRIPTION
# 概要
- index値を日付として表示
- CalendarBoardコンポーネントをリファクタリング

## 作業内容
- index値を日付として表示できるように、createCalendarメソッドを修正
- CalendarBoardを親コンポーネントとするCalendarElementコンポーネントを作成
- CalendarBoardコンポーネントからロジック部分を切り離し、src/services/calendar.jsに記述
- CalendarBoardコンポーネントからlocalize部分をsrc/index.jsに移動