### PR TITLE
Change month

### DIFF
--- a/src/components/CalendarBoard/container.jsx
+++ b/src/components/CalendarBoard/container.jsx
@@ -7,6 +7,7 @@ const mapStateToProps = state => ({
 });
 
 const mergeProps = stateProps => ({
+  month: stateProps.calendar,
   calendar: createCalendar(stateProps.calendar)
 });
 

--- a/src/components/CalendarBoard/index.jsx
+++ b/src/components/CalendarBoard/index.jsx
@@ -5,7 +5,7 @@ import "./style.css";
 
 const days = ["日", "月", "火", "水", "木", "金", "土"];
 
-const CalendarBoard = ({ calendar }) => {
+const CalendarBoard = ({ calendar, month }) => {
   return (
     <div className="container">
       <GridList className="grid" cols={7} spacing={0} cellHeight="auto">
@@ -24,7 +24,7 @@ const CalendarBoard = ({ calendar }) => {
         ))}
         {calendar.map(c => (
           <li key={c.toISOString()}>
-            <CalendarElement day={c} />
+            <CalendarElement day={c} month={month} />
           </li>
         ))}
       </GridList>

--- a/src/components/CalendarElement/index.jsx
+++ b/src/components/CalendarElement/index.jsx
@@ -2,9 +2,9 @@ import React from "react";
 import "./style.css";
 import { Typography } from "@material-ui/core";
 import dayjs from "dayjs";
-import { isSameDay, isSameMonth, isFirstDay } from "../../services/calendar";
+import { isSameDay, isSameMonth, isFirstDay, getMonth } from "../../services/calendar";
 
-const CalendarElement = ({ day }) => {
+const CalendarElement = ({ day, month }) => {
   const today = dayjs();
 
   // 月の最初にだけ月情報をつける
@@ -14,7 +14,8 @@ const CalendarElement = ({ day }) => {
   const isToday = isSameDay(day, today);
 
   // 今月以外をグレーダウン
-  const isCurrentMonth = isSameMonth(day, today);
+  const currentMonth = getMonth(month);
+  const isCurrentMonth = isSameMonth(day, currentMonth);
   const textColor = isCurrentMonth ? "textPrimary" : "textSecondary";
 
   return (

--- a/src/components/Navigation/container.jsx
+++ b/src/components/Navigation/container.jsx
@@ -1,16 +1,25 @@
 import { connect } from "react-redux";
 import Navigation from "./index";
+import { getNextMonth, getPreviousMonth } from "../../services/calendar";
+import { calendarSetMonth } from "../../redux/calendar/actions";
 
-const mapStateToProps = state => ({
-
-});
+const mapStateToProps = state => ({ calendar: state.calendar });
 
 const mapDispatchToProps = dispatch => ({
-
+  setMonth: month => {
+    dispatch(calendarSetMonth(month));
+  }
 });
 
 const mergeProps = (stateProps, dispatchProps) => ({
-
+  setNextMonth: () => {
+    const nextMonth = getNextMonth(stateProps.calendar);
+    dispatchProps.setMonth(nextMonth)
+  },
+  setPreviousMonth: () => {
+    const previousMonth = getPreviousMonth(stateProps.calendar);
+    dispatchProps.setMonth(previousMonth);
+  }
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Navigation);

--- a/src/components/Navigation/container.jsx
+++ b/src/components/Navigation/container.jsx
@@ -14,7 +14,7 @@ const mapDispatchToProps = dispatch => ({
 const mergeProps = (stateProps, dispatchProps) => ({
   setNextMonth: () => {
     const nextMonth = getNextMonth(stateProps.calendar);
-    dispatchProps.setMonth(nextMonth)
+    dispatchProps.setMonth(nextMonth);
   },
   setPreviousMonth: () => {
     const previousMonth = getPreviousMonth(stateProps.calendar);

--- a/src/components/Navigation/container.jsx
+++ b/src/components/Navigation/container.jsx
@@ -1,7 +1,7 @@
 import { connect } from "react-redux";
 import Navigation from "./index";
 import { getNextMonth, getPreviousMonth } from "../../services/calendar";
-import { calendarSetMonth } from "../../redux/calendar/actions";
+import { calendarSetMonth } from "../../redux/calendar/action";
 
 const mapStateToProps = state => ({ calendar: state.calendar });
 

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -3,7 +3,7 @@ import { IconButton, Toolbar, Typography, withStyles } from "@material-ui/core";
 import ArrowBackIos from "@material-ui/icons/ArrowBackIos";
 import ArrowForwardIos from "@material-ui/icons/ArrowForwardIos";
 import DehazeIcon from "@material-ui/icons/Dehaze";
-import DateRangeTwoToneIcon from '@material-ui/icons/DateRangeTwoTone';
+import DateRangeTwoToneIcon from "@material-ui/icons/DateRangeTwoTone";
 
 const StyledToobar = withStyles({
   root: { padding: "0" }

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -13,7 +13,7 @@ const StyledTypography = withStyles({
   root: { margin: "0 30px 0 10px" }
 })(Typography);
 
-const Navigation = () => {
+const Navigation = ({ setNextMonth, setPreviousMonth }) => {
   return (
     <StyledToobar>
       <IconButton>
@@ -23,10 +23,10 @@ const Navigation = () => {
       <StyledTypography color="textSecondary" variant="h5" component="h1">
         カレンダー
       </StyledTypography>
-      <IconButton size="small">
+      <IconButton size="small" onClick={setPreviousMonth}>
         <ArrowBackIos />
       </IconButton>
-      <IconButton size="small">
+      <IconButton size="small" onClick={setNextMonth}>
         <ArrowForwardIos />
       </IconButton>
     </StyledToobar>

--- a/src/redux/calendar/reducer.js
+++ b/src/redux/calendar/reducer.js
@@ -1,12 +1,10 @@
 import dayjs from "dayjs";
 import { CALENDAR_SET_MONTH } from "./action";
+import { formatMonth } from "../../services/calendar";
 
 const day = dayjs();
 
-const init = {
-  year: day.year(),
-  month: day.month() + 1
-};
+const init = formatMonth(day);
 
 const calendarReducer = (state = init, action) => {
   const { type, payload } = action;

--- a/src/services/calendar.js
+++ b/src/services/calendar.js
@@ -22,6 +22,21 @@ export const createCalendar = month => {
     });
 };
 
+export const getNextMonth = month => {
+  const day = getMonth(month).add(1, "month");
+  return formatMonth(day);
+};
+
+export const getPreviousMonth = month => {
+  const day = getMonth(month).add(-1, "month");
+  return formatMonth(day);
+};
+
+export const formatMonth = day => ({
+  month: day.month() + 1,
+  year: day.year()
+});
+
 export const getMonth = ({ year, month }) => {
   return dayjs(`${year}-${month}`);
 };


### PR DESCRIPTION
# 概要
前月、次月のカレンダーを表示できるようにイベントを追加

## 作業内容
- 前月、次月を取得するメソッドを実装
- 子コンポーネントからstoreにアクセスできるようにNavigation/container.jsxを修正
- NavigationのButtonに前月、次月に進むイベントを追加
- グレーアウトのエラーを修正