### PR TITLE
Preserve schedules

### DIFF
--- a/src/components/AddScheduleDialog/container.jsx
+++ b/src/components/AddScheduleDialog/container.jsx
@@ -1,6 +1,7 @@
 import AddScheduleDialog from "./index";
 import { connect } from "react-redux";
 import { addScheduleCloseDialog, addScheduleSetValue } from "../../redux/addSchedule/action";
+import { schedulesAddItem } from "../../redux/schedules/action";
 
 const mapStateToProps = state => ({ schedule: state.addSchedule });
 
@@ -10,7 +11,24 @@ const mapDispatchToProps = dispatch => ({
   },
   setSchedule: (value) => {
     dispatch(addScheduleSetValue(value));
+  },
+  saveSchedule: (schedule) => {
+    dispatch(schedulesAddItem(schedule));
+    dispatch(addScheduleCloseDialog());
   }
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(AddScheduleDialog);
+const mergeProps = (stateProps, dispatchProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  saveSchedule: () => {
+    const { schedule: { form: schedule }} = stateProps;
+    dispatchProps.saveSchedule(schedule);
+  }
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps
+)(AddScheduleDialog);

--- a/src/components/AddScheduleDialog/index.jsx
+++ b/src/components/AddScheduleDialog/index.jsx
@@ -33,7 +33,8 @@ const AddScheduleDialog = ({
     isDialogOpen 
   },
   closeDialog,
-  setSchedule
+  setSchedule,
+  saveSchedule
 }) => {
   return (
     <Dialog open={isDialogOpen} onClose={closeDialog} maxWidth="xs" fullWidth>
@@ -99,7 +100,7 @@ const AddScheduleDialog = ({
         </Grid>
       </DialogContent>
       <DialogActions>
-        <Button color="primary" variant="outlined">
+        <Button color="primary" variant="outlined" onClick={saveSchedule}>
             保存
         </Button>
       </DialogActions>

--- a/src/components/CalendarBoard/container.jsx
+++ b/src/components/CalendarBoard/container.jsx
@@ -4,7 +4,8 @@ import { createCalendar } from "../../services/calendar";
 import { addScheduleOpenDialog, addScheduleSetValue } from "../../redux/addSchedule/action";
 
 const mapStateToProps = state => ({
-  calendar: state.calendar
+  calendar: state.calendar,
+  schedules: state.schedules
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/CalendarBoard/container.jsx
+++ b/src/components/CalendarBoard/container.jsx
@@ -2,6 +2,7 @@ import { connect } from "react-redux";
 import CalendarBoard from "./index";
 import { createCalendar } from "../../services/calendar";
 import { addScheduleOpenDialog, addScheduleSetValue } from "../../redux/addSchedule/action";
+import { setSchedules } from "../../services/schedule";
 
 const mapStateToProps = state => ({
   calendar: state.calendar,
@@ -15,12 +16,17 @@ const mapDispatchToProps = dispatch => ({
   }
 });
 
-const mergeProps = (stateProps, dispatchProps) => ({
-  ...stateProps,
-  ...dispatchProps,
-  month: stateProps.calendar,
-  calendar: createCalendar(stateProps.calendar)
-});
+const mergeProps = (stateProps, dispatchProps) => {
+  const { calendar: month, schedules: { items: schedules }} = stateProps;
+  const calendar = setSchedules(createCalendar(month), schedules);
+
+  return {
+    ...stateProps,
+    ...dispatchProps,
+    month,
+    calendar
+  };
+};
 
 export default connect(
   mapStateToProps,

--- a/src/components/CalendarBoard/index.jsx
+++ b/src/components/CalendarBoard/index.jsx
@@ -5,7 +5,7 @@ import "./style.css";
 
 const days = ["日", "月", "火", "水", "木", "金", "土"];
 
-const CalendarBoard = ({ calendar, month, openAddScheduleDialog }) => {
+const CalendarBoard = ({ calendar, month, openAddScheduleDialog, schedules }) => {
   return (
     <div className="container">
       <GridList className="grid" cols={7} spacing={0} cellHeight="auto">

--- a/src/components/CalendarBoard/index.jsx
+++ b/src/components/CalendarBoard/index.jsx
@@ -5,7 +5,7 @@ import "./style.css";
 
 const days = ["日", "月", "火", "水", "木", "金", "土"];
 
-const CalendarBoard = ({ calendar, month, openAddScheduleDialog, schedules }) => {
+const CalendarBoard = ({ calendar, month, openAddScheduleDialog }) => {
   return (
     <div className="container">
       <GridList className="grid" cols={7} spacing={0} cellHeight="auto">
@@ -22,9 +22,9 @@ const CalendarBoard = ({ calendar, month, openAddScheduleDialog, schedules }) =>
             </Typography>
           </li>
         ))}
-        {calendar.map(c => (
-          <li key={c.toISOString()} onClick={() => openAddScheduleDialog(c)}>
-            <CalendarElement day={c} month={month} />
+        {calendar.map(({ date, schedules }) => (
+          <li key={date.toISOString()} onClick={() => openAddScheduleDialog(date)}>
+            <CalendarElement day={date} month={month} schedules={schedules} />
           </li>
         ))}
       </GridList>

--- a/src/services/schedule.js
+++ b/src/services/schedule.js
@@ -1,8 +1,8 @@
 import { isSameDay } from "./calendar";
 
-export const setSchedules = (calendar, schedules) => {
+export const setSchedules = (calendar, schedules) =>
   calendar.map(c => ({
     date: c,
     schedules: schedules.filter(e => isSameDay(e.date, c))
   }));
-};
+

--- a/src/services/schedule.js
+++ b/src/services/schedule.js
@@ -1,0 +1,8 @@
+import { isSameDay } from "./calendar";
+
+export const setSchedules = (calendar, schedules) => {
+  calendar.map(c => ({
+    date: c,
+    schedules: schedules.filter(e => isSameDay(e.date, c))
+  }));
+};


### PR DESCRIPTION
# 概要
予定を保存できるようにする

## 作業内容
- saveScheduleメソッドを実装
- ボタンにonClickイベントを実装
- カレンダーの日付と予定の日付を紐付けるロジックを実装
- カレンダー表示のロジックを変更

## 次回の実装内容
保存した予定を表示できるようにUIを変更する