### PR TITLE
Setup circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,33 +25,41 @@ jobs:
           name: install dependencies
           command: cd client && npm install
       - save_modules
-  test:
+  jest:
     executor: node
     steps:
-      - checkout
       - restore_modules
       - run:
           name: install dependencies
-          command: cd client && npm install
+          working_directory: client
+          command: npm install
       - run:
           name: unit test
-          command: cd client && npm test
-  lint:
+          command: npm test
+  eslint:
     executor: node
     steps:
-      - checkout
       - restore_modules
       - run:
           name: install dependencies
-          command: cd client && npm install
+          working_directory: client
+          command: npm install
       - run:
           name: execute eslint
-          command: cd client && npm run lint
+          working_directory: client
+          command: npm run lint
 
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build
-      - test
-      - lint
+      - jest
+        requires:
+          - build
+      - eslint
+        requires:
+          - build
+
+
+# 今後mysqlを用いる場合は、database.yml.ciも実装する必要がある

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ executors:
   node:
     docker:
       - image: circleci/node:12
+    working_directory: ~/calendar_app
   rails:
     docker:
       - image: circleci/ruby:2.6.2-node
@@ -21,13 +22,11 @@ commands:
   restore_modules_client:
     steps:
       - restore_cache:
-          key: dependency-cache-{{ checksum "./client/package-lock.json" }}
-  save_modules_client:
-    steps:
-      - save_cache:
-          key: dependency-cache-{{ checksum "./client/package-lock.json" }}
-          paths:
-            - ./node_modules
+          key: v4-calendar_app-{{ .Environment.CIRCLE_SHA2 }}
+      - restore_cache:
+          keys: 
+            - v3-dependencies-{{ checksum "client/package-lock.json" }}
+            - v3-dependencies
   install_bundler:
     steps:
       - run: gem install bundler -v 2.1.4
@@ -36,19 +35,30 @@ commands:
       - restore_cache:
           key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+          keys: 
+            - v2-dependencies-{{ checksum "Gemfile.lock" }}
+            - v2-dependencies
 
 jobs:
-  build:
+  fetch_source_code_client:
     executor: node
     steps:
       - checkout
+      - save_cache:
+          key: v4-calendar_app-{{ .Environment.CIRCLE_SHA2 }}
+          paths:
+            - ~/calendar_app
+  npm_dependencies:
+    executor: node
+    steps:
       - restore_modules_client
       - run:
-          name: install dependencies
-          working_directory: client
+          name: Npm Install Dependencies
           command: npm install
-      - save_modules_client
+      - save_cache:
+          key: v3-dependencies-{{ checksum "client/package-lock.json" }}
+          paths:
+            - client/node_modules
   jest:
     executor: node
     steps:
@@ -91,7 +101,7 @@ jobs:
       - install_bundler
       - run:
           name: Bundle Install Dependencies
-          command: bundle install
+          command: bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           key: v2-dependencies-{{ checksum "Gemfile.lock" }}
           paths:
@@ -123,7 +133,6 @@ jobs:
             bundle exec rspec --require rails_helper \
                               --color \
                               --format progress \
-                              --format RspecJunitFormatter \
                               --out ~/rspec/rspec.xml
       # collect reports
       - store_test_results:
@@ -145,13 +154,16 @@ workflows:
   version: 2
   build_and_test_client:
     jobs:
-      - build
+      - fetch_source_code_client
+      - npm_dependencies:
+          requires:
+            - fetch_source_code_client
       - jest:
           requires:
-            - build
+            - npm_dependencies
       - eslint:
           requires:
-            - build
+            - npm_dependencies
   build_and_test_server:
     jobs:
       - fetch_source_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,15 +140,6 @@ jobs:
       - store_artifacts:
           path: ~/tmp/test-results
           destination: test-results
-  rubocop:
-    executor:
-      name: rails
-    steps:
-      - restore_modules_server
-      - install_bundler
-      - run:
-          name: Execute rubocop
-          command: bundle exec rubocop
 
 workflows:
   version: 2
@@ -173,6 +164,4 @@ workflows:
       - rspec:
           requires:
             - bundle_dependencies
-      - rubocop:
-          requires:
-            - bundle_dependencies
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,16 +12,17 @@ executors:
           BUNDLE_RETRY: 3
           BUNDLE_PATH: vendor/bundle
           BUNDLER_VERSION: 2.1.4
-      - image: circleci/mysql:5.7.29-ram
+      - image: circleci/mysql:5.7.31-ram
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
+    working_directory: ~/calendar_app
 
 commands:
-  restore_modules:
+  restore_modules_client:
     steps:
       - restore_cache:
           key: dependency-cache-{{ checksum "./client/package-lock.json" }}
-  save_modules:
+  save_modules_client:
     steps:
       - save_cache:
           key: dependency-cache-{{ checksum "./client/package-lock.json" }}
@@ -30,32 +31,40 @@ commands:
   install_bundler:
     steps:
       - run: gem install bundler -v 2.1.4
+  restore_modules_server:
+    steps:
+      - restore_cache:
+          key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache:
+          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
 
 jobs:
   build:
     executor: node
     steps:
       - checkout
-      - restore_modules
+      - restore_modules_client
       - run:
           name: install dependencies
-          command: cd client && npm install
-      - save_modules
+          working_directory: client
+          command: npm install
+      - save_modules_client
   jest:
     executor: node
     steps:
-      - restore_modules
+      - restore_modules_client
       - run:
           name: install dependencies
           working_directory: client
           command: npm install
       - run:
           name: unit test
+          working_directory: client
           command: npm test
   eslint:
     executor: node
     steps:
-      - restore_modules
+      - restore_modules_client
       - run:
           name: install dependencies
           working_directory: client
@@ -78,15 +87,11 @@ jobs:
     executor:
       name: rails
     steps:
-      - restore_cache:
-          key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+      - restore_modules_server
       - install_bundler
       - run:
           name: Bundle Install Dependencies
-          command: |
-            bundle install
+          command: bundle install
       - save_cache:
           key: v2-dependencies-{{ checksum "Gemfile.lock" }}
           paths:
@@ -95,10 +100,7 @@ jobs:
     executor:
       name: rails
     steps:
-      - restore_cache:
-          key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+      - restore_modules_server
       - run:
           name: Watting stand up database
           command: |
@@ -131,27 +133,23 @@ jobs:
           destination: test-results
   rubocop:
     executor:
-      name: default_container
+      name: rails
     steps:
-      - restore_cache: # ソースコードの復元
-          key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache: # vendor/bundleを復元
-          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+      - restore_modules_server
       - install_bundler
       - run:
           name: Execute rubocop
-          command: |
-            bundle exec rubocop
+          command: bundle exec rubocop
 
 workflows:
   version: 2
   build_and_test_client:
     jobs:
       - build
-      - jest
+      - jest:
           requires:
             - build
-      - eslint
+      - eslint:
           requires:
             - build
   build_and_test_server:
@@ -164,7 +162,5 @@ workflows:
           requires:
             - bundle_dependencies
       - rubocop:
+          requires:
             - bundle_dependencies
-
-
-# 今後mysqlを用いる場合は、database.yml.ciも実装する必要がある

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,19 @@ executors:
   node:
     docker:
       - image: circleci/node:12
+  rails:
+    docker:
+      - image: circleci/ruby:2.6.2-node
+        environment:
+          RAILS_ENV: test
+          BUNDLE_JOBS: 4
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+          BUNDLER_VERSION: 2.1.4
+      - image: circleci/mysql:5.7.29-ram
+        environment:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+
 commands:
   restore_modules:
     steps:
@@ -14,6 +27,9 @@ commands:
           key: dependency-cache-{{ checksum "./client/package-lock.json" }}
           paths:
             - ./node_modules
+  install_bundler:
+    steps:
+      - run: gem install bundler -v 2.1.4
 
 jobs:
   build:
@@ -49,17 +65,106 @@ jobs:
           working_directory: client
           command: npm run lint
 
+  fetch_source_code:
+    executor:
+      name: rails
+    steps:
+      - checkout
+      - save_cache:
+          key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/calendar_app
+  bundle_dependencies:
+    executor:
+      name: rails
+    steps:
+      - restore_cache:
+          key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache:
+          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+      - install_bundler
+      - run:
+          name: Bundle Install Dependencies
+          command: |
+            bundle install
+      - save_cache:
+          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+  rspec:
+    executor:
+      name: rails
+    steps:
+      - restore_cache:
+          key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache:
+          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Watting stand up database
+          command: |
+            dockerize -wait \
+            tcp://127.0.0.1:3306 -timeout 120s
+      # Database setup
+      - run: mv ./config/database.yml.ci ./config/database.yml
+      - install_bundler
+      - run:
+          name: Testing DB migration and seed
+          command: |
+            bundle exec rails db:create db:migrate db:seed db:drop
+      - run:
+          name: Run rspec
+          command: |
+            mkdir /tmp/test-results
+            mkdir -p ~/rspec
+            bundle exec rails db:create db:migrate
+            TEST_FILES="$(circleci tests glob \"spec/**/*_spec.rb\" | circleci tests split --split-by=timings)"
+            bundle exec rspec --require rails_helper \
+                              --color \
+                              --format progress \
+                              --format RspecJunitFormatter \
+                              --out ~/rspec/rspec.xml
+      # collect reports
+      - store_test_results:
+          path: ~/rspec
+      - store_artifacts:
+          path: ~/tmp/test-results
+          destination: test-results
+  rubocop:
+    executor:
+      name: default_container
+    steps:
+      - restore_cache: # ソースコードの復元
+          key: v1-calendar_app-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache: # vendor/bundleを復元
+          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+      - install_bundler
+      - run:
+          name: Execute rubocop
+          command: |
+            bundle exec rubocop
+
 workflows:
   version: 2
-  build_and_test:
+  build_and_test_client:
     jobs:
       - build
       - jest
-        requires:
-          - build
+          requires:
+            - build
       - eslint
-        requires:
-          - build
+          requires:
+            - build
+  build_and_test_server:
+    jobs:
+      - fetch_source_code
+      - bundle_dependencies:
+          requires:
+            - fetch_source_code
+      - rspec:
+          requires:
+            - bundle_dependencies
+      - rubocop:
+            - bundle_dependencies
 
 
 # 今後mysqlを用いる場合は、database.yml.ciも実装する必要がある

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -1,0 +1,9 @@
+test:
+   adapter: mysql2
+   encoding: utf8
+   pool: 5
+   username: <%= ENV.fetch("MYSQL_USER", "root") %>
+   password:
+   host: <%= ENV.fetch("MYSQL_HOST", "127.0.0.1") %>
+   port: <%= ENV.fetch("MYSQL_PORT", "3306") %>
+   database: <%= ENV.fetch("MYSQL_DATABASE", "circleci-example-for-rails_test") %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,10 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'rspec/rails'
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 Faker::Config.locale = :ja
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
# 概要
circleciでserver sideのテストを実行できるようにする 

## 作業内容
- clientに関する記述を修正
- database.yml.ciを実装
- rspecを実行できるように実装
- `$bundle exec rubocop -a` を実行

## その他
rubocopを実行できるようにしたかったが、以下のエラーを解消できなかったため実装できなかった。
```
bundler: failed to load command: rubocop (/home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/bin/rubocop)
LoadError: cannot load such file -- parser/lexer
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/parser-2.7.1.4/lib/parser.rb:67:in `require'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/parser-2.7.1.4/lib/parser.rb:67:in `<module:Parser>'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/parser-2.7.1.4/lib/parser.rb:19:in `<top (required)>'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/rubocop-ast-0.3.0/lib/rubocop/ast.rb:3:in `require'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/rubocop-ast-0.3.0/lib/rubocop/ast.rb:3:in `<top (required)>'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/rubocop-ast-0.3.0/lib/rubocop-ast.rb:3:in `require_relative'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/rubocop-ast-0.3.0/lib/rubocop-ast.rb:3:in `<top (required)>'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/rubocop-0.89.1/lib/rubocop.rb:10:in `require'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/rubocop-0.89.1/lib/rubocop.rb:10:in `<top (required)>'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/rubocop-0.89.1/exe/rubocop:6:in `require'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/gems/rubocop-0.89.1/exe/rubocop:6:in `<top (required)>'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/bin/rubocop:23:in `load'
  /home/circleci/calendar_app/vendor/bundle/ruby/2.6.0/bin/rubocop:23:in `<top (required)>'

Exited with code exit status 1
CircleCI received exit code 1
```
